### PR TITLE
Pullreq skip nulls on write

### DIFF
--- a/src/main/scala/org/kiji/express/flow/KijiSource.scala
+++ b/src/main/scala/org/kiji/express/flow/KijiSource.scala
@@ -319,14 +319,14 @@ object KijiSource {
    */
   private def columnRequestsAllData(
       columns: Map[String, ColumnRequest]): Map[String, ColumnRequest] = {
-    val emptyOptions: ColumnRequestOptions =
-        new ColumnRequestOptions(Integer.MAX_VALUE, None, None)
+    def emptyOptions(skipNullsOnWrite: Boolean): ColumnRequestOptions =
+        new ColumnRequestOptions(Integer.MAX_VALUE, None, None, skipNullsOnWrite)
     val modifiedColumns = columns.mapValues {
-      case QualifiedColumn(family, qualifier, options) => {
-        new QualifiedColumn(family, qualifier, emptyOptions)
+      case QualifiedColumn(family, qualifier, ColumnRequestOptions(_, _, _, skipNullsOnWrite)) => {
+        new QualifiedColumn(family, qualifier, emptyOptions(skipNullsOnWrite))
       }
-      case ColumnFamily(family, qualField, options) => {
-        new ColumnFamily(family, qualField, emptyOptions)
+      case ColumnFamily(family, qualField, ColumnRequestOptions(_, _, _, skipNullsOnWrite)) => {
+        new ColumnFamily(family, qualField, emptyOptions(skipNullsOnWrite))
       }
     }
 

--- a/src/main/scala/org/kiji/express/flow/package.scala
+++ b/src/main/scala/org/kiji/express/flow/package.scala
@@ -312,4 +312,12 @@ package object flow {
     // Ensure that the timerange bounds are sensible.
     require(begin <= end, "Invalid time range specified: (%d, %d)".format(begin, end))
   }
+
+  /**
+   * Represents a value that will never be inserted in Kiji table.
+   */
+  @ApiAudience.Public
+  @ApiStability.Experimental
+  object Missing
+
 }


### PR DESCRIPTION
These commits allow us to 
1) not save nulls in a Kiji table automatically on a per column basis (this behavior is off by default)
2) have a Missing token in a cascading tuple that will never be saved in Kiji (as an alternative for those that do want to save nulls)

I also took the liberty to refactor ColumnRequest a tiny bit, introducing the case class copy method. I think for building fluent interfaces it is better to use copy than a constructor. The main reason is that as parameters (vals) get added to case classes we typically provide defaults for them in the constructor. This will mean the constructor used inside a fluent interface method will keep compiling after a parameter is added, but it will do the wrong thing (reset the new val to it's default value instead of preserving its value). Copy does the right thing.
